### PR TITLE
Fix numbering bug

### DIFF
--- a/_sources/branches/algebra/subspace.md
+++ b/_sources/branches/algebra/subspace.md
@@ -16,8 +16,8 @@ contributors: bookofproofs
 
 Let (`\(F,+,\cdot)\)` be a [field][bookofproofs$557] and `\(V\)` be a [vector space][bookofproofs$560] over `\(F\)`. A non-empty [subset][bookofproofs$552] `\(U\subseteq V\)` is called **subspace** of `\(V\)`, if
 1. `$0\in U,$`
-1. `$x + y\in U$` for all `$x,y\in U,$`
-1. `$\alpha\cdot x\in U$` for all `$\alpha \in F, x\in U.$`
+2. `$x + y\in U$` for all `$x,y\in U,$`
+3. `$\alpha\cdot x\in U$` for all `$\alpha \in F, x\in U.$`
 
 These properties are equivalent to those:
 * `\((U, + )\)` is a  [subgroup][bookofproofs$554] of `\((V, + )\)` and 

--- a/_sources/branches/algebra/subspace.md
+++ b/_sources/branches/algebra/subspace.md
@@ -7,18 +7,20 @@ title: Subspace
 description: SUBSPACE ★ bring your math skills to the graduate level ✔ step by step ✚ by the axiomatic method ➜ visit BookOfProofs now!
 references: bookofproofs$561
 keywords: subspace,subspaces
-contributors: bookofproofs
+contributors: bookofproofs,yonatanmgr
 
 ---
 
 
 ---
 
-Let (`\(F,+,\cdot)\)` be a [field][bookofproofs$557] and `\(V\)` be a [vector space][bookofproofs$560] over `\(F\)`. A non-empty [subset][bookofproofs$552] `\(U\subseteq V\)` is called **subspace** of `\(V\)`, if
+Let `\((F,+,\cdot)\)` be a [field][bookofproofs$557] and `\(V\)` be a [vector space][bookofproofs$560] over `\(F\)`. A non-empty [subset][bookofproofs$552] `\(U\subseteq V\)` is called **subspace** of `\(V\)`, if
+
 1. `$0\in U,$`
-2. `$x + y\in U$` for all `$x,y\in U,$`
-3. `$\alpha\cdot x\in U$` for all `$\alpha \in F, x\in U.$`
+1. `$x + y\in U$` for all `$x,y\in U,$`
+1. `$\alpha\cdot x\in U$` for all `$\alpha \in F, x\in U.$`
 
 These properties are equivalent to those:
+
 * `\((U, + )\)` is a  [subgroup][bookofproofs$554] of `\((V, + )\)` and 
 * `\(U\)` is closed under the [scalar multiplication][bookofproofs$560] by elements of `\(F\)`.


### PR DESCRIPTION
In https://bookofproofs.github.io/ the numbering appears as:
`1. 1. 1.`
instead of
`1. 2. 3.`
This commit should fix this.